### PR TITLE
Update ZT-LP-ZEU3S-WH-MS.yaml

### DIFF
--- a/Moes/ZT-LP-ZEU3S-WH-MS.yaml
+++ b/Moes/ZT-LP-ZEU3S-WH-MS.yaml
@@ -1,11 +1,11 @@
 blueprint:
   homeassistant:
     min_version: 2025.3.4
-  name: ZT-LP-ZEU3S-WH-MS (MQTT trigger)
+  name: Moes Self-Powered Zigbee Switch 3 Gang (ZT-LP-ZEU3S-WH-MS)
   description: "Controller automation for executing **press** actions
     triggered by Moes 3 Gang ZT-LP-ZEU3S-WH-MS switch.\n\n**SETTINGS**\nIn
     this tab, there is the possibility to change different parameters.\n  - **Controller Name**\n\n  - **Base
-    topic**\n\nℹ️ Version 0.1\n"
+    topic**\n\nℹ️ Version 0.2\n"
   domain: automation
   input:
     settings_section:

--- a/Moes/ZT-LP-ZEU3S-WH-MS.yaml
+++ b/Moes/ZT-LP-ZEU3S-WH-MS.yaml
@@ -66,11 +66,14 @@ conditions:
   - '{{ mqtt_topic.split("/")[1] in controller }}'
   - '{{ command in ("on","off","recall_scene1") }}'
 actions:
-- if: '{{ command == "off" }}'
+- if:
+    - '{{ command == "off" }}'
   then:
-    sequence: !input button_left_pressed
-  else if: '{{ command == "on" }}'
-  then:
-    sequence: !input button_middle_pressed
+    - sequence: !input button_left_pressed
   else:
-    sequence: !input button_right_pressed
+    - if:
+        - '{{ command == "on" }}'
+      then:
+        - sequence: !input button_middle_pressed
+      else:
+        - sequence: !input button_right_pressed


### PR DESCRIPTION
Hey, thanks so much for creating this blueprint. It didn't work for my 3 gang version so I've updated it to work. I got the following error: `Message malformed: extra keys not allowed @ data['actions'][0]['else if']`

Nesting else if fixed it.
Alternatively this also worked
```
actions:
- choose:
    - conditions:
        - '{{ command == "off" }}'
      sequence: !input button_left_pressed
    - conditions:
        - '{{ command == "on" }}'
      sequence: !input button_middle_pressed
  default:
    - sequence: !input button_right_pressed
```

I'm not sure if there's a preferred method though.

I wasn't sure whether to change it to Version 0.2
It also might be worth giving it a more readable name such as `Zigbee2MQTT - Moes Self-Powered Wireless Switch 3 Gang (ZT-LP-ZEU3S-WH-MS)`
If you're happy with that I can update the PR or you can update it directly.
Cheers!